### PR TITLE
Fet/reorganize steps

### DIFF
--- a/src/EE_Attendee_Importer.class.php
+++ b/src/EE_Attendee_Importer.class.php
@@ -116,6 +116,7 @@ class EE_Attendee_Importer extends EE_Addon
                 'EE_Registry' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\services\options\JsonWpOptionManager' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\AttendeeImporter\domain\services\import\managers\ui\ImportCsvAttendeesUiManager' => EE_Dependency_Map::load_from_cache,
             ),
             'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\ChooseEvent'                           => array(
                 'EE_Registry' => EE_Dependency_Map::load_from_cache,
@@ -126,7 +127,6 @@ class EE_Attendee_Importer extends EE_Addon
                 'EE_Registry' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\services\options\JsonWpOptionManager' => EE_Dependency_Map::load_from_cache,
-                '\EventEspresso\AttendeeImporter\domain\services\import\managers\ui\ImportCsvAttendeesUiManager' => EE_Dependency_Map::load_from_cache,
             ),
             'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\Complete'                                => array(
                 'EE_Registry' => EE_Dependency_Map::load_from_cache,

--- a/src/application/services/import/config/ImportConfigBase.php
+++ b/src/application/services/import/config/ImportConfigBase.php
@@ -52,7 +52,7 @@ abstract class ImportConfigBase implements ImportConfigInterface
     {
         if (! $this->model_configs_initialized) {
             $this->model_configs = $this->initializeModelConfigCollection();
-            if (! $this->model_configs instanceof CollectionInterface){
+            if (! $this->model_configs instanceof CollectionInterface) {
                 throw new InvalidEntityException(
                     $this->model_configs,
                     'EventEspresso\AttendeeImporter\application\services\import\config\models\ImportModelConfigInterface'

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/ChooseEvent.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/ChooseEvent.php
@@ -122,7 +122,7 @@ class ChooseEvent extends ImportCsvAttendeesStep
                 ]
             ]
         );
-        if (count($tickets) === 1){
+        if (count($tickets) === 1) {
             $ticket = reset($tickets);
             $this->config->setTicketId($ticket->ID());
             $this->setRedirectTo(SequentialStepForm::REDIRECT_TO_OTHER);

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/ChooseEvent.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/ChooseEvent.php
@@ -126,11 +126,6 @@ class ChooseEvent extends ImportCsvAttendeesStep
             $ticket = reset($tickets);
             $this->config->setTicketId($ticket->ID());
             $this->setRedirectTo(SequentialStepForm::REDIRECT_TO_OTHER);
-            $this->removeRedirectArgs(
-                [
-                    'ee-form-step'
-                ]
-            );
             $this->addRedirectArgs(
                 [
                     'ee-form-step' => 'upload'

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/ChooseEvent.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/ChooseEvent.php
@@ -8,6 +8,8 @@ use EE_Form_Section_Proper;
 use EE_Registry;
 use EE_Select_Ajax_Model_Rest_Input;
 use EED_Attendee_Importer;
+use EEH_URL;
+use EEM_Ticket;
 use EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidFormSubmissionException;
@@ -48,7 +50,7 @@ class ChooseEvent extends ImportCsvAttendeesStep
     ) {
         $this->setDisplayable(true);
         parent::__construct(
-            3,
+            1,
             esc_html__('Choose Event', 'event_espresso'),
             esc_html__('"Choose Event" Attendee Importer Step', 'event_espresso'),
             'choose-event',
@@ -111,9 +113,40 @@ class ChooseEvent extends ImportCsvAttendeesStep
             return;
         }
         $this->config->setEventId($valid_data['event']);
+
+        // If there is only one ticket for this event, we can set the default ticket now and skip that step.
+        $tickets = EEM_Ticket::instance()->get_all(
+            [
+                [
+                    'Datetime.EVT_ID' => $this->config->getEventId()
+                ]
+            ]
+        );
+        if (count($tickets) === 1){
+            $ticket = reset($tickets);
+            $this->config->setTicketId($ticket->ID());
+            $this->setRedirectTo(SequentialStepForm::REDIRECT_TO_OTHER);
+            $this->removeRedirectArgs(
+                [
+                    'ee-form-step'
+                ]
+            );
+            $this->addRedirectArgs(
+                [
+                    'ee-form-step' => 'upload'
+                ]
+            );
+            EE_Error::add_success(
+                esc_html__(
+                    'Ticket Selection step skipped because there is only one ticket for the event selected.',
+                    'event_espresso'
+                )
+            );
+        } else {
+            $this->setRedirectTo(SequentialStepForm::REDIRECT_TO_NEXT_STEP);
+        }
         $this->option_manager->saveToDb($this->config);
-        // If there is only one ticket for this event, we can set the default ticket now and skip that step.s
-        $this->setRedirectTo(SequentialStepForm::REDIRECT_TO_NEXT_STEP);
+
         return true;
     }
 }

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/ChooseTicket.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/ChooseTicket.php
@@ -95,16 +95,6 @@ class ChooseTicket extends ImportCsvAttendeesStep
                             'default' => $this->config->getTicketId()
                         ]
                     ),
-                    'notice' => new EE_Form_Section_HTML(
-                        EEH_HTML::p(
-                            esc_html__(
-                                // @codingStandardsIgnoreStart
-                                'The import will start after this step. Please wait for it to complete before closing this window, turning off your computer, or navigating away.',
-                                // @codingStandardsIgnoreEnd
-                                'event_espresso'
-                            )
-                        )
-                    )
                 ]
             ]
         );
@@ -133,7 +123,7 @@ class ChooseTicket extends ImportCsvAttendeesStep
 
         $this->config->setTicketId($valid_data['ticket']);
         $this->option_manager->saveToDb($this->config);
-
+        $this->setRedirectTo(SequentialStepForm::REDIRECT_TO_NEXT_STEP);
         return true;
     }
 }

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/ChooseTicket.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/ChooseTicket.php
@@ -36,11 +36,6 @@ use LogicException;
 class ChooseTicket extends ImportCsvAttendeesStep
 {
     /**
-     * @var ImportCsvAttendeesUiManager
-     */
-    private $attendeesUiManager;
-
-    /**
      * ChooseTicket constructor
      *
      * @param EE_Registry $registry
@@ -54,13 +49,11 @@ class ChooseTicket extends ImportCsvAttendeesStep
     public function __construct(
         EE_Registry $registry,
         ImportCsvAttendeesConfig $config,
-        JsonWpOptionManager $option_manager,
-        ImportCsvAttendeesUiManager $attendeesUiManager
+        JsonWpOptionManager $option_manager
     ) {
         $this->setDisplayable(true);
-        $this->attendeesUiManager = $attendeesUiManager;
         parent::__construct(
-            4,
+            2,
             esc_html__('Choose Ticket', 'event_espresso'),
             esc_html__('"Choose Ticket" Attendee Importer Step', 'event_espresso'),
             'choose-ticket',
@@ -140,37 +133,8 @@ class ChooseTicket extends ImportCsvAttendeesStep
 
         $this->config->setTicketId($valid_data['ticket']);
         $this->option_manager->saveToDb($this->config);
-        $this->redirectToBatchJob();
-        return true;
-    }
 
-    protected function redirectToBatchJob()
-    {
-        wp_redirect(
-            EE_Admin_Page::add_query_args_and_nonce(
-                array(
-                    'page'        => 'espresso_batch',
-                    'batch'       => 'job',
-                    'label'       => esc_html__('Applying Offset', 'event_espresso'),
-                    'job_handler' => urlencode(get_class($this->attendeesUiManager->getBatchJobHandler())),
-                    'return_url'  => urlencode(
-                        add_query_arg(
-                            array(
-                                'ee-form-step' => 'complete',
-                            ),
-                            EEH_URL::current_url_without_query_paramaters(
-                                array(
-                                    'ee-form-step',
-                                    'return',
-                                )
-                            )
-                        )
-                    ),
-                ),
-                admin_url()
-            )
-        );
-        exit;
+        return true;
     }
 }
 // End of file ChooseTicket.php

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/Complete.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/Complete.php
@@ -69,7 +69,9 @@ class Complete extends ImportCsvAttendeesStep
                 [
                 'action'   => 'default',
                 'event_id' => $this->config->getEventId(),
-            ], REG_ADMIN_URL)
+                ],
+                REG_ADMIN_URL
+            )
         );
     }
 

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/StepsManager.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/StepsManager.php
@@ -77,10 +77,10 @@ class StepsManager extends SequentialStepFormManager
                         'FHEE__EventEspresso\AttendeeImporter\core\domain\services\import\csv\attendees\forms\form_handlers\StepsManager__getFormStepsCollection__form_step_classes',
                         // @codingStandardsIgnoreEnd
                         array(
-                            'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\UploadCsv',
-                            'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\MapCsvColumns',
                             'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\ChooseEvent',
                             'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\ChooseTicket',
+                            'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\UploadCsv',
+                            'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\MapCsvColumns',
                             'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\Complete',
                         )
                     ),
@@ -100,4 +100,4 @@ class StepsManager extends SequentialStepFormManager
     }
 }
 // End of file StesManager.php
-// Location: EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers/StesManager.php
+// Location: EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers/StepsManager.php

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/UploadCSV.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/UploadCSV.php
@@ -45,7 +45,7 @@ class UploadCsv extends ImportCsvAttendeesStep
     {
         $this->setDisplayable(true);
         parent::__construct(
-            1,
+            3,
             esc_html__('Upload', 'event_espresso'),
             esc_html__('"Upload" Attendee Importer Step', 'event_espresso'),
             'upload',

--- a/src/domain/services/import/csv/attendees/forms/forms/MapCsvColumnsForm.php
+++ b/src/domain/services/import/csv/attendees/forms/forms/MapCsvColumnsForm.php
@@ -2,10 +2,12 @@
 namespace EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\forms;
 
 use EE_Error;
+use EE_Form_Section_HTML;
 use EE_Form_Section_HTML_From_Template;
 use EE_Form_Section_Proper;
 use EE_Model_Field_Base;
 use EE_Select_Input;
+use EEH_HTML;
 use EEM_Answer;
 use EEM_Attendee;
 use EEM_Base;
@@ -42,6 +44,16 @@ class MapCsvColumnsForm extends EE_Form_Section_Proper
                         wp_normalize_path(dirname(dirname(dirname(__FILE__))) . '/templates/ee_attendee_importer_mapping_instructions.template.php')
                     ),
                     'columns' => LoaderFactory::getLoader()->getNew('EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\forms\MapCsvColumnsSubform'),
+                    'notice' => new EE_Form_Section_HTML(
+                        EEH_HTML::p(
+                            esc_html__(
+                            // @codingStandardsIgnoreStart
+                                'The import will start after this step. Please wait for it to complete before closing this window, turning off your computer, or navigating away.',
+                                // @codingStandardsIgnoreEnd
+                                'event_espresso'
+                            )
+                        )
+                    )
                 ],
                 'html_style' => 'display:flex'
             ],

--- a/src/domain/services/import/csv/attendees/forms/forms/MapCsvColumnsSubform.php
+++ b/src/domain/services/import/csv/attendees/forms/forms/MapCsvColumnsSubform.php
@@ -6,6 +6,7 @@ use EE_Form_Section_Proper;
 use EE_Model_Field_Base;
 use EE_Select_Input;
 use EEM_Answer;
+use EEM_Event;
 use EEM_Question_Group;
 use EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig;
 use EventEspresso\AttendeeImporter\application\services\import\mapping\ImportFieldMap;
@@ -90,7 +91,15 @@ class MapCsvColumnsSubform extends EE_Form_Section_Proper
             }
         }
         // And add questions (group by question group).
-        foreach (EEM_Question_Group::instance()->get_all() as $question_group) {
+        $question_groups_for_event = EEM_Question_Group::instance()->get_all(
+            [
+                [
+                    'Event_Question_Group.EVT_ID'      => $this->config->getEventId(),
+                    'QSG_deleted'                      => false,
+                ]
+            ]
+        );
+        foreach ($question_groups_for_event as $question_group) {
             foreach ($question_group->questions() as $question) {
                 if ($question->is_system_question()) {
                     if ($question->system_ID() === 'state') {

--- a/src/domain/services/import/managers/ui/ImportCsvAttendeesUiManager.php
+++ b/src/domain/services/import/managers/ui/ImportCsvAttendeesUiManager.php
@@ -51,7 +51,7 @@ class ImportCsvAttendeesUiManager extends ImportTypeUiManagerBase
                     // base redirect URL
                     $base_url,
                     // default step slug
-                    'upload',
+                    'choose-event',
                 )
             );
             $this->form_steps_manager->buildForm();

--- a/src/ui/admin/attendee_importer/Attendee_Importer_Admin_Page.core.php
+++ b/src/ui/admin/attendee_importer/Attendee_Importer_Admin_Page.core.php
@@ -1,5 +1,4 @@
 <?php
-use EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\StepsManager;
 use EventEspresso\core\exceptions\ExceptionStackTraceDisplay;
 use EventEspresso\core\libraries\form_sections\form_handlers\InvalidFormHandlerException;
 use EventEspresso\core\services\loaders\LoaderFactory;


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Reorganized steps so choosing event and ticket come first.
Skip choosing the ticket if there is only one for the event.
Only show questions from question groups on the event we are importing to.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Create a new question group, and an event that uses it (but no other optional question groups). Just create one ticket on that new event. Import to it. The ticket selection step should be skipped (instead there is a notice saying why it was skipped), and when mapping, you should NOT see the address questions (because you don't ask for them on this event), only the new question group and the personal info question group.
* [ ] Create another event which only asks the address questions, and import to it. You should see the address questions while mapping, but not the custom question group created earlier (because it's not used on this event)
* [ ] Create another event with a few tickets and migrate to it. The ticket selection step should not be skipped.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
