### PR TITLE
Add verify step to attendee importer

### DIFF
--- a/samples/ee3-attendee-importer-sample-0-rows.csv
+++ b/samples/ee3-attendee-importer-sample-0-rows.csv
@@ -1,0 +1,1 @@
+First,Last,Email,QTY,Event ID,Amount Paid,Payment Status,Price Option,Answers (optional)

--- a/samples/ee3-attendee-importer-sample-1-row.csv
+++ b/samples/ee3-attendee-importer-sample-1-row.csv
@@ -1,0 +1,2 @@
+First,Last,Email,QTY,Event ID,Amount Paid,Payment Status,Price Option,Answers (optional)
+John,Doe,noreply@eventespresso.com,2,57,2.5,Completed,General Admission,4|| 6 | 7 |

--- a/samples/ee3-attendee-importer-sample.csv
+++ b/samples/ee3-attendee-importer-sample.csv
@@ -1,3 +1,3 @@
 First,Last,Email,QTY,Event ID,Amount Paid,Payment Status,Price Option,Event Date,Event Time,Answers (optional)
-John,Doe,noreply@eventespresso.com,2,57,2.5,Completed,General Admission,9/28/12,8:00 PM,"4, 5, 6"
-Jane,Doe,noreply@eventespresso.com,1,57,2.5,Completed,General Admission,9/28/12,8:00 PM,"1,2"
+John,Doe,noreply@eventespresso.com,2,57,2.5,Completed,General Admission,9/28/12,8:00 PM,4| 123 West My Street || 6 | Some City || 7 | Utah
+Jane,Doe,noreply@eventespresso.com,1,57,2.5,Completed,General Admission,9/28/12,8:00 PM,4| 321 Cool Street || 6 | Large City || 7 | Arizona

--- a/samples/ee3-attendee-importer-sample.csv
+++ b/samples/ee3-attendee-importer-sample.csv
@@ -1,1 +1,3 @@
-0,Registration ID (optional),First,Last,Email,QTY,Event ID,Amount Paid,Payment Status,Price Option,Event Date,Event Time,Answers (optional)1,,John,Doe,noreply@eventespresso.com,2,57,2.5,Completed,General Admission,9/28/12,8:00 PM,4| 123 West My Street || 6 | Some City || 7 | Utah1,,Jane,Doe,noreply@eventespresso.com,1,57,2.5,Completed,General Admission,9/28/12,8:00 PM,4| 321 Cool Street || 6 | Large City || 7 | Arizona
+First,Last,Email,QTY,Event ID,Amount Paid,Payment Status,Price Option,Event Date,Event Time,Answers (optional)
+John,Doe,noreply@eventespresso.com,2,57,2.5,Completed,General Admission,9/28/12,8:00 PM,4| 123 West My Street || 6 | Some City || 7 | Utah
+Jane,Doe,noreply@eventespresso.com,1,57,2.5,Completed,General Admission,9/28/12,8:00 PM,4| 321 Cool Street || 6 | Large City || 7 | Arizona

--- a/samples/ee3-attendee-importer-sample.csv
+++ b/samples/ee3-attendee-importer-sample.csv
@@ -1,3 +1,3 @@
 First,Last,Email,QTY,Event ID,Amount Paid,Payment Status,Price Option,Event Date,Event Time,Answers (optional)
-John,Doe,noreply@eventespresso.com,2,57,2.5,Completed,General Admission,9/28/12,8:00 PM,4| 123 West My Street || 6 | Some City || 7 | Utah
-Jane,Doe,noreply@eventespresso.com,1,57,2.5,Completed,General Admission,9/28/12,8:00 PM,4| 321 Cool Street || 6 | Large City || 7 | Arizona
+John,Doe,noreply@eventespresso.com,2,57,2.5,Completed,General Admission,9/28/12,8:00 PM,"4, 5, 6"
+Jane,Doe,noreply@eventespresso.com,1,57,2.5,Completed,General Admission,9/28/12,8:00 PM,"1,2"

--- a/samples/ee3-attendee-importer-sample.csv
+++ b/samples/ee3-attendee-importer-sample.csv
@@ -1,3 +1,3 @@
-First,Last,Email,QTY,Event ID,Amount Paid,Payment Status,Price Option,Event Date,Event Time,Answers (optional)
-John,Doe,noreply@eventespresso.com,2,57,2.5,Completed,General Admission,9/28/12,8:00 PM,4|| 6 | 7 |
-Jane,Doe,noreply@eventespresso.com,1,57,2.5,Completed,General Admission,9/28/12,8:00 PM,"1,3,4"
+First,Last,Email,QTY,Event ID,Amount Paid,Payment Status,Price Option,Answers (optional)
+John,Doe,noreply@eventespresso.com,2,57,2.5,Completed,General Admission,4|| 6 | 7 |
+Jane,Doe,noreply@eventespresso.com,1,57,2.5,Completed,General Admission,"1,3,4"

--- a/samples/ee3-attendee-importer-sample.csv
+++ b/samples/ee3-attendee-importer-sample.csv
@@ -1,3 +1,3 @@
 First,Last,Email,QTY,Event ID,Amount Paid,Payment Status,Price Option,Event Date,Event Time,Answers (optional)
-John,Doe,noreply@eventespresso.com,2,57,2.5,Completed,General Admission,9/28/12,8:00 PM,4| 123 West My Street || 6 | Some City || 7 | Utah
-Jane,Doe,noreply@eventespresso.com,1,57,2.5,Completed,General Admission,9/28/12,8:00 PM,4| 321 Cool Street || 6 | Large City || 7 | Arizona
+John,Doe,noreply@eventespresso.com,2,57,2.5,Completed,General Admission,9/28/12,8:00 PM,4|| 6 | 7 |
+Jane,Doe,noreply@eventespresso.com,1,57,2.5,Completed,General Admission,9/28/12,8:00 PM,"1,3,4"

--- a/src/EE_Attendee_Importer.class.php
+++ b/src/EE_Attendee_Importer.class.php
@@ -132,6 +132,10 @@ class EE_Attendee_Importer extends EE_Addon
                 'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\services\options\JsonWpOptionManager' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\AttendeeImporter\domain\services\import\managers\ui\ImportCsvAttendeesUiManager' => EE_Dependency_Map::load_from_cache,
+                'EEM_Event' => EE_Dependency_Map::load_from_cache,
+                'EEM_Ticket' => EE_Dependency_Map::load_from_cache,
+                'EEM_Attendee' => EE_Dependency_Map::load_from_cache,
+                'EEM_Question_Group' => EE_Dependency_Map::load_from_cache,
             ),
             'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\Complete'                                => array(
                 'EE_Registry' => EE_Dependency_Map::load_from_cache,

--- a/src/EE_Attendee_Importer.class.php
+++ b/src/EE_Attendee_Importer.class.php
@@ -116,7 +116,6 @@ class EE_Attendee_Importer extends EE_Addon
                 'EE_Registry' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\services\options\JsonWpOptionManager' => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\AttendeeImporter\domain\services\import\managers\ui\ImportCsvAttendeesUiManager' => EE_Dependency_Map::load_from_cache,
             ),
             'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\ChooseEvent'                           => array(
                 'EE_Registry' => EE_Dependency_Map::load_from_cache,
@@ -127,6 +126,12 @@ class EE_Attendee_Importer extends EE_Addon
                 'EE_Registry' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\services\options\JsonWpOptionManager' => EE_Dependency_Map::load_from_cache,
+            ),
+            'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\Verify'                           => array(
+                'EE_Registry' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\options\JsonWpOptionManager' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\AttendeeImporter\domain\services\import\managers\ui\ImportCsvAttendeesUiManager' => EE_Dependency_Map::load_from_cache,
             ),
             'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\Complete'                                => array(
                 'EE_Registry' => EE_Dependency_Map::load_from_cache,

--- a/src/EE_Attendee_Importer.class.php
+++ b/src/EE_Attendee_Importer.class.php
@@ -137,17 +137,22 @@ class EE_Attendee_Importer extends EE_Addon
                 array(),
                 'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig' => EE_Dependency_Map::load_from_cache,
             ],
+            'EventEspresso\AttendeeImporter\domain\services\commands\ImportCommand' => [
+                'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\options\JsonWpOptionManager' => EE_Dependency_Map::load_from_cache,
+            ],
             // commands handlers
             'EventEspresso\AttendeeImporter\domain\services\commands\ImportCommandHandler' => [
                 'EventEspresso\core\services\commands\CommandBusInterface' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\services\commands\CommandFactoryInterface' => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig' => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\core\services\options\JsonWpOptionManager' => EE_Dependency_Map::load_from_cache,
             ],
             'EventEspresso\AttendeeImporter\domain\services\commands\ImportAttendeeCommandHandler' => [
                 'EventEspresso\core\services\commands\CommandBusInterface' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\services\commands\CommandFactoryInterface' => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig' => EE_Dependency_Map::load_from_cache,
+            ],
+            'EventEspresso\AttendeeImporter\domain\services\commands\ImportPaymentCommandHandler' => [
+                'EventEspresso\core\services\commands\CommandBusInterface' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\commands\CommandFactoryInterface' => EE_Dependency_Map::load_from_cache,
             ],
             'EventEspresso\AttendeeImporter\domain\services\commands\ImportAnswersCommandHandler' => [
                 'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig' => EE_Dependency_Map::load_from_cache,

--- a/src/application/services/import/config/ImportConfigBase.php
+++ b/src/application/services/import/config/ImportConfigBase.php
@@ -99,7 +99,9 @@ abstract class ImportConfigBase implements ImportConfigInterface
             && $data->json_model_configs instanceof stdClass) {
             foreach ($data->json_model_configs as $json_key => $json_value) {
                     $obj = $this->getModelConfigs()->get($json_key);
-                    $obj->fromJsonSerializedData($json_value);
+                    if($obj instanceof ImportModelConfigInterface){
+                        $obj->fromJsonSerializedData($json_value);
+                    }
             }
             return true;
         }

--- a/src/application/services/import/config/ImportConfigBase.php
+++ b/src/application/services/import/config/ImportConfigBase.php
@@ -99,9 +99,9 @@ abstract class ImportConfigBase implements ImportConfigInterface
             && $data->json_model_configs instanceof stdClass) {
             foreach ($data->json_model_configs as $json_key => $json_value) {
                     $obj = $this->getModelConfigs()->get($json_key);
-                    if($obj instanceof ImportModelConfigInterface){
-                        $obj->fromJsonSerializedData($json_value);
-                    }
+                if ($obj instanceof ImportModelConfigInterface) {
+                    $obj->fromJsonSerializedData($json_value);
+                }
             }
             return true;
         }

--- a/src/application/services/import/config/models/ImportModelConfigBase.php
+++ b/src/application/services/import/config/models/ImportModelConfigBase.php
@@ -159,6 +159,26 @@ abstract class ImportModelConfigBase implements ImportModelConfigInterface
     }
 
     /**
+     * Gets the mapping info for the specified model field (eg EEM_Attendee's `ATT_fname` field).
+     * Or null if the field wasn't mapped.
+     * @since $VID:$
+     * @param $field_name
+     * @return ImportFieldMap|null
+     * @throws CollectionDetailsException
+     * @throws CollectionLoaderException
+     * @throws EE_Error
+     */
+    public function getMappingInfoForField($field_name)
+    {
+        foreach ($this->mapping() as $mapped_field) {
+            if ($mapped_field->destinationFieldName() === $field_name) {
+                return $mapped_field;
+            }
+        }
+        return null;
+    }
+
+    /**
      * @since $VID:$
      * @return mixed|void
      */

--- a/src/application/services/import/config/models/ImportPaymentConfig.php
+++ b/src/application/services/import/config/models/ImportPaymentConfig.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace EventEspresso\AttendeeImporter\application\services\import\config\models;
+
+use EE_Model_Field_Base;
+use EEM_Attendee;
+use EEM_Base;
+use EEM_Payment;
+use EventEspresso\AttendeeImporter\application\services\import\config\ImportModelConfigInterface;
+use EventEspresso\AttendeeImporter\application\services\import\mapping\ImportMappingCollection;
+
+/**
+ * Class ImportPaymentConfig
+ *
+ * Description
+ *
+ * @package     Event Espresso
+ * @author         Mike Nelson
+ * @since         $VID:$
+ *
+ */
+class ImportPaymentConfig extends ImportModelConfigBase
+{
+
+
+    /**
+     * Gets the model this configuration is for
+     * @since $VID:$
+     * @return EEM_Base
+     */
+    public function getModel()
+    {
+        return EEM_Payment::instance();
+    }
+
+
+    /**
+     * Gets the names of the fields on this model that are mapped.
+     * @since $VID:$
+     * @return string[]
+     */
+    public function fieldNamesMapped()
+    {
+        return [
+            'PAY_amount',
+//            'PMD_ID'
+        ];
+    }
+}
+// End of file ImportPaymentConfig.php
+// Location: EventEspresso\AttendeeImporter\application\services\import\config\models/ImportPaymentConfig.php

--- a/src/application/services/import/config/models/ImportPaymentConfig.php
+++ b/src/application/services/import/config/models/ImportPaymentConfig.php
@@ -12,7 +12,7 @@ use EventEspresso\AttendeeImporter\application\services\import\mapping\ImportMap
 /**
  * Class ImportPaymentConfig
  *
- * Description
+ * Configuration saying how to import a payment from source data.
  *
  * @package     Event Espresso
  * @author         Mike Nelson
@@ -43,7 +43,6 @@ class ImportPaymentConfig extends ImportModelConfigBase
     {
         return [
             'PAY_amount',
-//            'PMD_ID'
         ];
     }
 }

--- a/src/domain/services/commands/ImportAnswersCommand.php
+++ b/src/domain/services/commands/ImportAnswersCommand.php
@@ -32,12 +32,12 @@ class ImportAnswersCommand extends ImportBaseCommand
      * CreateAttendeeCommand constructor.
      *
      * @param EE_Registration $registration
-     * @param array $csv_row
+     * @param array $input_data
      */
-    public function __construct(EE_Registration $registration, array $csv_row)
+    public function __construct(EE_Registration $registration, array $input_data)
     {
         $this->registration = $registration;
-        parent::__construct($csv_row);
+        parent::__construct($input_data);
     }
 
     /**

--- a/src/domain/services/commands/ImportAnswersCommandHandler.php
+++ b/src/domain/services/commands/ImportAnswersCommandHandler.php
@@ -56,7 +56,10 @@ class ImportAnswersCommandHandler extends CommandHandler
             $question = EEM_Question::instance()->get_one_by_ID($question_id);
             $answer = $command->csvColumnValue($csv_column);
             if (EEM_Question::instance()->question_type_is_in_category($question->type(), 'multi-answer-enum')) {
-                $answer = explode(',', $answer);
+                $answer = array_map(
+                    'trim',
+                    explode(',', $answer)
+                );
             }
             $answer = EE_Answer::new_instance(
                 [

--- a/src/domain/services/commands/ImportAnswersCommandHandler.php
+++ b/src/domain/services/commands/ImportAnswersCommandHandler.php
@@ -56,7 +56,10 @@ class ImportAnswersCommandHandler extends CommandHandler
             $question = EEM_Question::instance()->get_one_by_ID($question_id);
             $answer = $command->csvColumnValue($csv_column);
             if (EEM_Question::instance()->question_type_is_in_category($question->type(), 'multi-answer-enum')) {
-                $answer = explode(',', $answer);
+                $answer = array_map(
+                    'trim',
+                    explode('|', $answer)
+                );
             }
             $answer = EE_Answer::new_instance(
                 [

--- a/src/domain/services/commands/ImportAnswersCommandHandler.php
+++ b/src/domain/services/commands/ImportAnswersCommandHandler.php
@@ -56,10 +56,7 @@ class ImportAnswersCommandHandler extends CommandHandler
             $question = EEM_Question::instance()->get_one_by_ID($question_id);
             $answer = $command->csvColumnValue($csv_column);
             if (EEM_Question::instance()->question_type_is_in_category($question->type(), 'multi-answer-enum')) {
-                $answer = array_map(
-                    'trim',
-                    explode(',', $answer)
-                );
+                $answer = explode(',', $answer);
             }
             $answer = EE_Answer::new_instance(
                 [

--- a/src/domain/services/commands/ImportAttendeeCommand.php
+++ b/src/domain/services/commands/ImportAttendeeCommand.php
@@ -3,6 +3,7 @@
 namespace EventEspresso\AttendeeImporter\domain\services\commands;
 
 use EE_Registration;
+use EventEspresso\AttendeeImporter\application\services\import\config\models\ImportAttendeeConfig;
 
 /**
  * Class CreateAttendeeCommand
@@ -11,7 +12,7 @@ use EE_Registration;
  * @package       Event Espresso
  * @author        Michael Nelson
  */
-class ImportAttendeeCommand extends ImportBaseCommand
+class ImportAttendeeCommand extends ImportSingleModelBase
 {
 
     /**
@@ -19,9 +20,12 @@ class ImportAttendeeCommand extends ImportBaseCommand
      */
     private $registration;
 
-    public function __construct(EE_Registration $reg, array $csv_row)
-    {
-        parent::__construct($csv_row);
+    public function __construct(
+        EE_Registration $reg,
+        array $input_data,
+        ImportAttendeeConfig $config
+    ) {
+        parent::__construct($input_data, $config);
         $this->registration = $reg;
     }
 

--- a/src/domain/services/commands/ImportAttendeeCommandHandler.php
+++ b/src/domain/services/commands/ImportAttendeeCommandHandler.php
@@ -2,23 +2,14 @@
 
 namespace EventEspresso\AttendeeImporter\domain\services\commands;
 
-use DomainException;
 use EE_Attendee;
 use EE_Attendee_Importer_Config;
 use EE_Error;
-use EEM_Attendee;
-use EventEspresso\AttendeeImporter\application\services\import\config\models\ImportModelConfigInterface;
-use EventEspresso\AttendeeImporter\application\services\import\mapping\ImportFieldMap;
-use EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
-use EventEspresso\core\services\commands\CommandBusInterface;
-use EventEspresso\core\services\commands\CommandFactoryInterface;
-use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
 use EventEspresso\core\services\commands\CompositeCommandHandler;
-use EventEspresso\core\services\options\JsonWpOptionManager;
 use InvalidArgumentException;
 use ReflectionException;
 
@@ -31,23 +22,6 @@ use ReflectionException;
  */
 class ImportAttendeeCommandHandler extends CompositeCommandHandler
 {
-    /**
-     * @var EE_Attendee_Importer_Config
-     */
-    protected $importer_config;
-    /**
-     * @var ImportCsvAttendeesConfig
-     */
-    private $config;
-
-    public function __construct(
-        CommandBusInterface $command_bus,
-        CommandFactoryInterface $command_factory,
-        ImportCsvAttendeesConfig $config
-    ) {
-        parent::__construct($command_bus, $command_factory);
-        $this->config = $config;
-    }
 
     /**
      * @param CommandInterface|ImportAttendeeCommand $command
@@ -62,28 +36,12 @@ class ImportAttendeeCommandHandler extends CompositeCommandHandler
     public function handle(CommandInterface $command)
     {
         // Create an attendee
-        $attendee_config = $this->config->getModelConfigs()->get('Attendee');
-        if (!$attendee_config instanceof ImportModelConfigInterface) {
-            throw new InvalidEntityException(
-                $attendee_config,
-                'EventEspresso\AttendeeImporter\application\services\import\config\models\ImportModelConfigInterface'
-            );
-        }
-        $fields_mapped = $attendee_config->mapping();
-        $attendee_fields = [];
-        foreach ($fields_mapped as $field_mapped) {
-            /* @var $field_mapped ImportFieldMap */
-            $attendee_fields[ $field_mapped->destinationFieldName() ] = $field_mapped->applyMap(
-                $command->csvColumnValue(
-                    $field_mapped->sourceProperty()
-                )
-            );
-        }
+
         $attendee = $this->commandBus()->execute(
             $this->commandFactory()->getNew(
                 'EventEspresso\core\services\commands\attendee\CreateAttendeeCommand',
                 [
-                    $attendee_fields,
+                    $command->getFieldsFromMappedData(),
                     $command->getRegistration()
                 ]
             )

--- a/src/domain/services/commands/ImportBaseCommand.php
+++ b/src/domain/services/commands/ImportBaseCommand.php
@@ -21,19 +21,19 @@ use EventEspresso\core\services\commands\CommandRequiresCapCheckInterface;
 class ImportBaseCommand extends Command implements CommandRequiresCapCheckInterface
 {
     /**
-     * @var array $csv_row
+     * @var array $input_data
      */
-    protected $csv_row;
+    protected $input_data;
 
 
     /**
      * CreateAttendeeCommand constructor.
      *
-     * @param array           $csv_row
+     * @param array           $input_data
      */
-    public function __construct(array $csv_row)
+    public function __construct(array $input_data)
     {
-        $this->csv_row = $csv_row;
+        $this->input_data = $input_data;
     }
 
 
@@ -53,7 +53,7 @@ class ImportBaseCommand extends Command implements CommandRequiresCapCheckInterf
      */
     public function csvRow()
     {
-        return $this->csv_row;
+        return $this->input_data;
     }
 
     /**
@@ -64,7 +64,7 @@ class ImportBaseCommand extends Command implements CommandRequiresCapCheckInterf
      */
     public function csvColumnValue($column_name)
     {
-        return isset($this->csv_row[ $column_name ]) ? $this->csv_row[ $column_name ] : null;
+        return isset($this->input_data[ $column_name ]) ? $this->input_data[ $column_name ] : null;
     }
 }
 // End of file ModelObjFromCsvRowCommand.php

--- a/src/domain/services/commands/ImportCommand.php
+++ b/src/domain/services/commands/ImportCommand.php
@@ -2,6 +2,9 @@
 
 namespace EventEspresso\AttendeeImporter\domain\services\commands;
 
+use EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig;
+use EventEspresso\core\services\options\JsonWpOptionManager;
+
 /**
  * Class CreateAttendeeCommand
  * DTO for passing data to a ImportCommandHandler
@@ -11,5 +14,37 @@ namespace EventEspresso\AttendeeImporter\domain\services\commands;
  */
 class ImportCommand extends ImportBaseCommand
 {
+    /**
+     * @var ImportCsvAttendeesConfig
+     */
+    private $config;
 
+    private $config_populated_from_db = false;
+    /**
+     * @var JsonWpOptionManager
+     */
+    private $option_manager;
+
+    public function __construct(
+        array $input_data,
+        ImportCsvAttendeesConfig $config,
+        JsonWpOptionManager $option_manager
+    ) {
+        parent::__construct($input_data);
+        $this->config = $config;
+        $this->option_manager = $option_manager;
+    }
+
+    /**
+     * Takes care of always populating it from the DB on first call.
+     * @since $VID:$
+     * @return ImportCsvAttendeesConfig
+     */
+    public function getConfig(){
+        if (! $this->config_populated_from_db) {
+            $this->option_manager->populateFromDb($this->config);
+            $this->config_populated_from_db = true;
+        }
+        return $this->config;
+    }
 }

--- a/src/domain/services/commands/ImportCommand.php
+++ b/src/domain/services/commands/ImportCommand.php
@@ -40,7 +40,8 @@ class ImportCommand extends ImportBaseCommand
      * @since $VID:$
      * @return ImportCsvAttendeesConfig
      */
-    public function getConfig(){
+    public function getConfig()
+    {
         if (! $this->config_populated_from_db) {
             $this->option_manager->populateFromDb($this->config);
             $this->config_populated_from_db = true;

--- a/src/domain/services/commands/ImportCommandHandler.php
+++ b/src/domain/services/commands/ImportCommandHandler.php
@@ -6,6 +6,8 @@ use EE_Answer;
 use EE_Attendee;
 use EE_Error;
 use EE_Registration;
+use EE_Registration_Processor;
+use EE_Registry;
 use EEH_Line_Item;
 use EEM_Question;
 use EEM_Registration;
@@ -69,11 +71,11 @@ class ImportCommandHandler extends CompositeCommandHandler
                     $transaction,
                     $line_item,
                     1,
-                    null,
-                    EEM_Registration::status_id_approved
+                    null
                 ]
             )
         );
+        EE_Registry::instance()->load_class('Registration_Processor')->toggle_incomplete_registration_status_to_default($registration,false);
         $attendee = $this->commandBus()->execute(
             $this->commandFactory()->getNew(
                 'EventEspresso\AttendeeImporter\domain\services\commands\ImportAttendeeCommand',

--- a/src/domain/services/commands/ImportCommandHandler.php
+++ b/src/domain/services/commands/ImportCommandHandler.php
@@ -75,7 +75,7 @@ class ImportCommandHandler extends CompositeCommandHandler
                 ]
             )
         );
-        EE_Registry::instance()->load_class('Registration_Processor')->toggle_incomplete_registration_status_to_default($registration,false);
+        EE_Registry::instance()->load_class('Registration_Processor')->toggle_incomplete_registration_status_to_default($registration, false);
         $attendee = $this->commandBus()->execute(
             $this->commandFactory()->getNew(
                 'EventEspresso\AttendeeImporter\domain\services\commands\ImportAttendeeCommand',

--- a/src/domain/services/commands/ImportPaymentCommand.php
+++ b/src/domain/services/commands/ImportPaymentCommand.php
@@ -2,13 +2,11 @@
 
 namespace EventEspresso\AttendeeImporter\domain\services\commands;
 
-use EE_Registration;
+use EE_Transaction;
+use EventEspresso\AttendeeImporter\application\services\import\config\models\ImportModelConfigBase;
 use EventEspresso\core\domain\services\capabilities\CapCheck;
 use EventEspresso\core\domain\services\capabilities\CapCheckInterface;
-use EventEspresso\core\domain\services\capabilities\PublicCapabilities;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
-use EventEspresso\core\services\commands\Command;
-use EventEspresso\core\services\commands\CommandRequiresCapCheckInterface;
 
 /**
  * Class CreateAttendeeCommand
@@ -17,43 +15,30 @@ use EventEspresso\core\services\commands\CommandRequiresCapCheckInterface;
  * @package       Event Espresso
  * @author        Michael Nelson
  */
-class ImportPaymentCommand extends Command implements CommandRequiresCapCheckInterface
+class ImportPaymentCommand extends ImportSingleModelBase
 {
-
-    /**
-     * array of details where keys are names of EEM_Attendee model fields
-     *
-     * @var array $csv_row
-     */
-    protected $csv_row;
 
     /**
      * an existing registration to associate this attendee with
      *
-     * @var EE_Registration $registration
+     * @var EE_Transaction $transaction
      */
-    protected $registration;
+    protected $transaction;
 
-
-    /**
-     * CreateAttendeeCommand constructor.
-     *
-     * @param array           $csv_row
-     * @param EE_Registration $config
-     */
-    public function __construct(array $csv_row, \EE_Attendee_Importer_Config $config)
-    {
-        $this->csv_row = $csv_row;
-        $this->registration = $config;
+    public function __construct(
+        EE_Transaction$transaction,
+        array $input_data,
+        ImportModelConfigBase $config
+    ) {
+        $this->transaction = $transaction;
+        parent::__construct($input_data, $config);
     }
 
-
     /**
-     * @return CapCheckInterface
-     * @throws InvalidDataTypeException
+     * @return EE_Transaction
      */
-    public function getCapCheck()
+    public function getTransaction()
     {
-        return new CapCheck('import', 'ee_attendee_import');
+        return $this->transaction;
     }
 }

--- a/src/domain/services/commands/ImportPaymentCommand.php
+++ b/src/domain/services/commands/ImportPaymentCommand.php
@@ -4,9 +4,6 @@ namespace EventEspresso\AttendeeImporter\domain\services\commands;
 
 use EE_Transaction;
 use EventEspresso\AttendeeImporter\application\services\import\config\models\ImportModelConfigBase;
-use EventEspresso\core\domain\services\capabilities\CapCheck;
-use EventEspresso\core\domain\services\capabilities\CapCheckInterface;
-use EventEspresso\core\exceptions\InvalidDataTypeException;
 
 /**
  * Class CreateAttendeeCommand

--- a/src/domain/services/commands/ImportPaymentCommandHandler.php
+++ b/src/domain/services/commands/ImportPaymentCommandHandler.php
@@ -4,8 +4,12 @@ namespace EventEspresso\AttendeeImporter\domain\services\commands;
 
 use EE_Attendee;
 use EE_Error;
+use EE_Payment;
+use EE_Payment_Processor;
 use EE_Registration;
 use EEM_Attendee;
+use EEM_Payment;
+use EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig;
 use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
@@ -19,41 +23,42 @@ use EventEspresso\core\services\commands\CommandInterface;
  */
 class ImportPaymentCommandHandler extends CommandHandler
 {
-
-
     /**
-     */
-    public function __construct()
-    {
-    }
-
-
-    /**
-     * @param CommandInterface $command
+     * @param CommandInterface|ImportPaymentCommand $command
      * @return EE_Attendee
      * @throws EE_Error
      * @throws InvalidEntityException
      */
     public function handle(CommandInterface $command)
     {
-        /** @var ImportPaymentCommand $command */
-        if (! $command instanceof ImportPaymentCommand) {
-            throw new InvalidEntityException(get_class($command), 'CreateAttendeeCommand');
+        $payment_data = $command->getFieldsFromMappedData();
+        // Don't make a payment if they didn't specify an amount.
+        if (empty($payment_data)) {
+            return null;
         }
-//        $this->commandBus()->execute(
-//            $this->commandFactory()->getNew(
-//                'EventEspresso\core\services\commands\transaction\CreateTransactionCommand'
-//            )
-//        );
-        // TODO: Use commands to...
-        // Create an attendee
-        // Create a transaction
-        // Get a ticket
-        // Get an event
-        // Create a registration
-        // Create answers
-        // Create a registration-answer row
-        // Create line items
-        return null;
+        add_filter(
+            'FHEE__EED_Messages___maybe_registration__deliver_notifications',
+            '__return_false',
+            20
+        );
+        remove_all_filters('AHEE__EE_Payment_Processor__update_txn_based_on_payment__successful');
+        $payment_data['TXN_ID'] = $command->getTransaction()->ID();
+        $payment_data['STS_ID'] = EEM_Payment::status_id_approved;
+        $payment_data['PAY_timestamp'] = $command->getTransaction()->get_DateTime_object('TXN_timestamp');
+        $payment_data['PAY_source'] = esc_html__('Imported', 'event_espresso');
+        $payment_data['PMD_ID'] = \EEM_Payment_Method::instance()->get_var(
+            [
+                [
+                    'PMD_slug' => 'other'
+                ]
+            ],
+            'PMD_ID'
+        );
+        $payment = EE_Payment::new_instance($payment_data);
+        $payment->save();
+        // No messages while importing thanks.
+
+        EE_Payment_Processor::instance()->update_txn_based_on_payment($command->getTransaction(), $payment);
+        return $payment;
     }
 }

--- a/src/domain/services/commands/ImportPaymentCommandHandler.php
+++ b/src/domain/services/commands/ImportPaymentCommandHandler.php
@@ -16,7 +16,7 @@ use EventEspresso\core\services\commands\CommandInterface;
 
 /**
  * Class CreateAttendeeCommandHandler
- * generates and validates an Attendee
+ * generates and validates an Payment
  *
  * @package       Event Espresso
  * @author        Brent Christensen

--- a/src/domain/services/commands/ImportSingleModelBase.php
+++ b/src/domain/services/commands/ImportSingleModelBase.php
@@ -25,8 +25,8 @@ class ImportSingleModelBase extends ImportBaseCommand
 
     public function __construct(
         array $input_data,
-        ImportModelConfigBase $config)
-    {
+        ImportModelConfigBase $config
+    ) {
         parent::__construct($input_data);
         $this->config = $config;
     }
@@ -53,8 +53,6 @@ class ImportSingleModelBase extends ImportBaseCommand
         }
         return $fields;
     }
-
-
 }
 // End of file ImportSingleModelBase.php
 // Location: EventEspresso\AttendeeImporter\domain\services\commands/ImportSingleModelBase.php

--- a/src/domain/services/commands/ImportSingleModelBase.php
+++ b/src/domain/services/commands/ImportSingleModelBase.php
@@ -9,7 +9,7 @@ use EventEspresso\core\services\collections\CollectionLoaderException;
 /**
  * Class ImportSingleModelBase
  *
- * Description
+ * Base configuration for when we're importing a single model object from the input data.
  *
  * @package     Event Espresso
  * @author         Mike Nelson

--- a/src/domain/services/commands/ImportSingleModelBase.php
+++ b/src/domain/services/commands/ImportSingleModelBase.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace EventEspresso\AttendeeImporter\domain\services\commands;
+
+use EventEspresso\AttendeeImporter\application\services\import\config\models\ImportModelConfigBase;
+use EventEspresso\core\services\collections\CollectionDetailsException;
+use EventEspresso\core\services\collections\CollectionLoaderException;
+
+/**
+ * Class ImportSingleModelBase
+ *
+ * Description
+ *
+ * @package     Event Espresso
+ * @author         Mike Nelson
+ * @since         $VID:$
+ *
+ */
+class ImportSingleModelBase extends ImportBaseCommand
+{
+    /**
+     * @var ImportModelConfigBase
+     */
+    private $config;
+
+    public function __construct(
+        array $input_data,
+        ImportModelConfigBase $config)
+    {
+        parent::__construct($input_data);
+        $this->config = $config;
+    }
+
+    /**
+     * Gets an array where keys are model field names, and values are their coerced values fromthe input data.
+     * @since $VID:$
+     * @return array
+     * @throws \EE_Error
+     * @throws CollectionDetailsException
+     * @throws CollectionLoaderException
+     */
+    public function getFieldsFromMappedData()
+    {
+        $fields_mapped = $this->config->mapping();
+        $fields = [];
+        foreach ($fields_mapped as $field_mapped) {
+            /* @var $field_mapped ImportFieldMap */
+            $fields[ $field_mapped->destinationFieldName() ] = $field_mapped->applyMap(
+                $this->csvColumnValue(
+                    $field_mapped->sourceProperty()
+                )
+            );
+        }
+        return $fields;
+    }
+
+
+}
+// End of file ImportSingleModelBase.php
+// Location: EventEspresso\AttendeeImporter\domain\services\commands/ImportSingleModelBase.php

--- a/src/domain/services/import/csv/attendees/config/ImportCsvAttendeesConfig.php
+++ b/src/domain/services/import/csv/attendees/config/ImportCsvAttendeesConfig.php
@@ -159,7 +159,8 @@ class ImportCsvAttendeesConfig extends ImportConfigBase
                 'EventEspresso\AttendeeImporter\application\services\import\config\models\ImportModelConfigBase',
                 // FQCNs for classes to add (all classes within that namespace will be loaded)
                 [
-                    'EventEspresso\AttendeeImporter\application\services\import\config\models\ImportAttendeeConfig'
+                    'EventEspresso\AttendeeImporter\application\services\import\config\models\ImportAttendeeConfig',
+                    'EventEspresso\AttendeeImporter\application\services\import\config\models\ImportPaymentConfig'
                 ],
                 [],
                 '',

--- a/src/domain/services/import/csv/attendees/config/ImportCsvAttendeesConfig.php
+++ b/src/domain/services/import/csv/attendees/config/ImportCsvAttendeesConfig.php
@@ -132,7 +132,10 @@ class ImportCsvAttendeesConfig extends ImportConfigBase
      */
     public function setQuestionMapping(array $question_mapping)
     {
-        $this->question_mapping = $question_mapping;
+        $this->question_mapping = [];
+        foreach($question_mapping as $question_id => $column) {
+            $this->question_mapping[intval( $question_id)] = $column;
+        }
     }
 
     public function clearMapping()

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/Complete.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/Complete.php
@@ -52,7 +52,7 @@ class Complete extends ImportCsvAttendeesStep
         JsonWpOptionManager $option_manager
     ) {
         parent::__construct(
-            5,
+            6,
             esc_html__('Complete', 'event_espresso'),
             esc_html__('"Complete" Attendee Mover Step', 'event_espresso'),
             'complete',

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/MapCsvColumns.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/MapCsvColumns.php
@@ -35,10 +35,6 @@ use LogicException;
  */
 class MapCsvColumns extends ImportCsvAttendeesStep
 {
-    /**
-     * @var ImportCsvAttendeesUiManager
-     */
-    private $attendeesUiManager;
 
     /**
      * MapCsvColumns constructor
@@ -54,11 +50,9 @@ class MapCsvColumns extends ImportCsvAttendeesStep
     public function __construct(
         EE_Registry $registry,
         ImportCsvAttendeesConfig $config,
-        JsonWpOptionManager $option_manager,
-        ImportCsvAttendeesUiManager $attendeesUiManager
+        JsonWpOptionManager $option_manager
     ) {
         $this->setDisplayable(true);
-        $this->attendeesUiManager = $attendeesUiManager;
         parent::__construct(
             4,
             esc_html__('Map CSV Columns To Event Espresso Data', 'event_espresso'),
@@ -122,36 +116,7 @@ class MapCsvColumns extends ImportCsvAttendeesStep
         }
         $this->config->setQuestionMapping($question_mapping);
         $this->option_manager->saveToDb($this->config);
-        $this->setRedirectTo(SequentialStepForm::REDIRECT_TO_OTHER);
-        $this->removeRedirectArgs(
-            [
-                'ee-form-step'
-            ]
-        );
-        $this->setRedirectUrl(
-            EE_Admin_Page::add_query_args_and_nonce(
-                array(
-                    'page'        => 'espresso_batch',
-                    'batch'       => 'job',
-                    'label'       => esc_html__('Applying Offset', 'event_espresso'),
-                    'job_handler' => urlencode(get_class($this->attendeesUiManager->getBatchJobHandler())),
-                    'return_url'  => urlencode(
-                        add_query_arg(
-                            array(
-                                'ee-form-step' => 'complete',
-                            ),
-                            EEH_URL::current_url_without_query_paramaters(
-                                array(
-                                    'ee-form-step',
-                                    'return',
-                                )
-                            )
-                        )
-                    ),
-                ),
-                admin_url()
-            )
-        );
+        $this->setRedirectTo(SequentialStepForm::REDIRECT_TO_NEXT_STEP);
         return true;
     }
 }

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/MapCsvColumns.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/MapCsvColumns.php
@@ -42,7 +42,6 @@ class MapCsvColumns extends ImportCsvAttendeesStep
      * @param EE_Registry $registry
      * @param ImportCsvAttendeesConfig $config
      * @param JsonWpOptionManager $option_manager
-     * @param ImportCsvAttendeesUiManager $attendeesUiManager
      * @throws DomainException
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/MapCsvColumns.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/MapCsvColumns.php
@@ -106,7 +106,7 @@ class MapCsvColumns extends ImportCsvAttendeesStep
         foreach ($valid_data['columns'] as $column_name => $model_and_field) {
             $model_and_field_array = explode('.', $model_and_field, 2);
             if ($model_and_field_array[0] === 'Question') {
-                $question_mapping[ $model_and_field_array[1] ] = $column_name;
+                $question_mapping[ (int) $model_and_field_array[1] ] = $column_name;
             }
             $model_config = $model_configs->get($model_and_field_array[0]);
             if ($model_config instanceof ImportModelConfigInterface) {

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/StepsManager.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/StepsManager.php
@@ -81,6 +81,7 @@ class StepsManager extends SequentialStepFormManager
                             'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\ChooseTicket',
                             'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\UploadCsv',
                             'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\MapCsvColumns',
+                            'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\Verify',
                             'EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\form_handlers\Complete',
                         )
                     ),

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/Verify.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/Verify.php
@@ -66,6 +66,7 @@ class Verify extends ImportCsvAttendeesStep
     )
     {
         $this->setDisplayable(true);
+        $this->setFormConfig(FormHandler::ADD_FORM_TAGS_ONLY);
         parent::__construct(
             5,
             esc_html__('Verify', 'event_espresso'),
@@ -91,7 +92,7 @@ class Verify extends ImportCsvAttendeesStep
     {
         $this->option_manager->populateFromDb($this->config);
 
-        return new EE_Form_Section_Proper(
+        $form = new EE_Form_Section_Proper(
             [
                 'name' => 'verify',
                 'subsections' => [
@@ -120,10 +121,24 @@ class Verify extends ImportCsvAttendeesStep
                                 'event_espresso'
                             )
                         )
+                        . EEH_HTML::p(
+                            esc_html__(
+                            // @codingStandardsIgnoreStart
+                                'Please ensure you have a database backup so you can easily revert the import if it doesn’t work as expected.',
+                                // @codingStandardsIgnoreEnd
+                                'event_espresso'
+                            )
+                        )
                     )
                 ]
             ]
         );
+        $form->add_subsections(
+            array($this->slug() . '-submit-btn' => $this->generateSubmitButton(esc_html__('I have a database backup. Begin Import', 'event_espresso'))),
+            null,
+            false
+        );
+        return $form;
     }
 
     protected function getReverseMapping()
@@ -253,7 +268,6 @@ class Verify extends ImportCsvAttendeesStep
             // Don't die. Admin code knows how to handle invalid forms...
             return;
         }
-
         $this->setRedirectTo(SequentialStepForm::REDIRECT_TO_OTHER);
         $this->removeRedirectArgs(
             [

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/Verify.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/Verify.php
@@ -237,8 +237,9 @@ class Verify extends ImportCsvAttendeesStep
             foreach ($question_group->questions() as $question) {
                 // Try to find the column, assuming its a custom question.
                 $column_name = null;
-                if (isset($question_ids_to_column_names[ $question->ID() ])) {
-                    $column_name = $question_ids_to_column_names[ $question->ID() ];
+                $question_id = (int) $question->ID();
+                if (array_key_exists($question_id, $question_ids_to_column_names)) {
+                    $column_name = $question_ids_to_column_names[ $question_id ];
                 } else {
                     $attendee_field = $this->attendee_model->get_attendee_field_for_system_question($question->system_ID());
                     $mapping_info = $attendee_config->getMappingInfoForField($attendee_field);

--- a/src/domain/services/import/csv/attendees/forms/form_handlers/Verify.php
+++ b/src/domain/services/import/csv/attendees/forms/form_handlers/Verify.php
@@ -63,8 +63,7 @@ class Verify extends ImportCsvAttendeesStep
         ImportCsvAttendeesConfig $config,
         JsonWpOptionManager $option_manager,
         ImportCsvAttendeesUiManager $attendeesUiManager
-    )
-    {
+    ) {
         $this->setDisplayable(true);
         $this->setFormConfig(FormHandler::ADD_FORM_TAGS_ONLY);
         parent::__construct(
@@ -133,8 +132,13 @@ class Verify extends ImportCsvAttendeesStep
                 ]
             ]
         );
+        // Make our own submit button, with different text.
         $form->add_subsections(
-            array($this->slug() . '-submit-btn' => $this->generateSubmitButton(esc_html__('I have a database backup. Begin Import', 'event_espresso'))),
+            [
+                $this->slug() . '-submit-btn' => $this->generateSubmitButton(
+                    esc_html__('I have a database backup. Begin Import', 'event_espresso')
+                )
+            ],
             null,
             false
         );
@@ -239,7 +243,7 @@ class Verify extends ImportCsvAttendeesStep
                 ];
             }
 
-            if (! empty($question_rows)){
+            if (! empty($question_rows)) {
                 $table_rows[] = $question_group->name(true);
                 $table_rows = array_merge($table_rows, $question_rows);
             }

--- a/src/domain/services/import/csv/attendees/forms/forms/MapCsvColumnsForm.php
+++ b/src/domain/services/import/csv/attendees/forms/forms/MapCsvColumnsForm.php
@@ -44,16 +44,6 @@ class MapCsvColumnsForm extends EE_Form_Section_Proper
                         wp_normalize_path(dirname(dirname(dirname(__FILE__))) . '/templates/ee_attendee_importer_mapping_instructions.template.php')
                     ),
                     'columns' => LoaderFactory::getLoader()->getNew('EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\forms\forms\MapCsvColumnsSubform'),
-                    'notice' => new EE_Form_Section_HTML(
-                        EEH_HTML::p(
-                            esc_html__(
-                            // @codingStandardsIgnoreStart
-                                'The import will start after this step. Please wait for it to complete before closing this window, turning off your computer, or navigating away.',
-                                // @codingStandardsIgnoreEnd
-                                'event_espresso'
-                            )
-                        )
-                    )
                 ],
                 'html_style' => 'display:flex'
             ],

--- a/src/domain/services/import/csv/attendees/templates/attendee_importer_verify_info.template.php
+++ b/src/domain/services/import/csv/attendees/templates/attendee_importer_verify_info.template.php
@@ -1,0 +1,42 @@
+
+<p><b><?php esc_html_e('Event','event_espresso' );?></b> <?php echo $event instanceof EE_Event ? $event->name() : esc_html__('None','event_espresso' );?></p>
+<p><b><?php esc_html_e('Ticket','event_espresso' );?></b> <?php echo $ticket instanceof EE_Ticket ? $ticket->name() : esc_html__('None','event_espresso' );?></p>
+
+<table class="ee-responsive-table">
+    <thead>
+    <tr>
+    <th><?php esc_html_e('Event Espresso Data','event_espresso' );?></th>
+    <th><?php esc_html_e('CSV Data','event_espresso' );?></th>
+    <th><?php esc_html_e('Sample #1','event_espresso' );?></th>
+    <th><?php esc_html_e('Sample #2','event_espresso' );?></th>
+    </tr>
+    </thead>
+    <tbody>
+    <?php
+    foreach ($table_rows as $table_row) {
+    ?>
+    <tr>
+        <?php
+        if (is_string($table_row)) {
+            ?>
+            <td colspan="4">
+                <h2><?php echo $table_row;?></h2>
+            </td>
+            <?php
+        } else {
+            foreach ($table_row as $cell) {
+                ?>
+                <td>
+                <?php
+                echo $cell;
+                ?>
+                </td><?php
+            }
+        }
+        ?>
+        </tr>
+        <?php
+    }
+    ?>
+    </tbody>
+</table>

--- a/src/domain/services/import/csv/attendees/templates/attendee_importer_verify_info.template.php
+++ b/src/domain/services/import/csv/attendees/templates/attendee_importer_verify_info.template.php
@@ -1,6 +1,6 @@
 
-<p><b><?php esc_html_e('Event', 'event_espresso');?></b> <?php echo $event instanceof EE_Event ? $event->name() : esc_html__('None', 'event_espresso');?></p>
-<p><b><?php esc_html_e('Ticket', 'event_espresso');?></b> <?php echo $ticket instanceof EE_Ticket ? $ticket->name() : esc_html__('None', 'event_espresso');?></p>
+<p><b><?php esc_html_e('Event', 'event_espresso');?></b> <?php echo esc_html( $event instanceof EE_Event ? $event->name() : esc_html__('None', 'event_espresso'));?></p>
+<p><b><?php esc_html_e('Ticket', 'event_espresso');?></b> <?php echo esc_html( $ticket instanceof EE_Ticket ? $ticket->name() : esc_html__('None', 'event_espresso'));?></p>
 
 <table class="ee-responsive-table">
     <thead>
@@ -20,7 +20,7 @@
         if (is_string($table_row)) {
             ?>
             <td colspan="4">
-                <h2><?php echo $table_row;?></h2>
+                <h2><?php echo esc_html($table_row);?></h2>
             </td>
             <?php
         } else {
@@ -28,7 +28,7 @@
                 ?>
                 <td>
                 <?php
-                echo $cell;
+                echo esc_html($cell);
                 ?>
                 </td><?php
             }

--- a/src/domain/services/import/csv/attendees/templates/attendee_importer_verify_info.template.php
+++ b/src/domain/services/import/csv/attendees/templates/attendee_importer_verify_info.template.php
@@ -1,14 +1,14 @@
 
-<p><b><?php esc_html_e('Event','event_espresso' );?></b> <?php echo $event instanceof EE_Event ? $event->name() : esc_html__('None','event_espresso' );?></p>
-<p><b><?php esc_html_e('Ticket','event_espresso' );?></b> <?php echo $ticket instanceof EE_Ticket ? $ticket->name() : esc_html__('None','event_espresso' );?></p>
+<p><b><?php esc_html_e('Event', 'event_espresso');?></b> <?php echo $event instanceof EE_Event ? $event->name() : esc_html__('None', 'event_espresso');?></p>
+<p><b><?php esc_html_e('Ticket', 'event_espresso');?></b> <?php echo $ticket instanceof EE_Ticket ? $ticket->name() : esc_html__('None', 'event_espresso');?></p>
 
 <table class="ee-responsive-table">
     <thead>
     <tr>
-    <th><?php esc_html_e('Event Espresso Data','event_espresso' );?></th>
-    <th><?php esc_html_e('CSV Data','event_espresso' );?></th>
-    <th><?php esc_html_e('Sample #1','event_espresso' );?></th>
-    <th><?php esc_html_e('Sample #2','event_espresso' );?></th>
+    <th><?php esc_html_e('Event Espresso Data', 'event_espresso');?></th>
+    <th><?php esc_html_e('CSV Data', 'event_espresso');?></th>
+    <th><?php esc_html_e('Sample #1', 'event_espresso');?></th>
+    <th><?php esc_html_e('Sample #2', 'event_espresso');?></th>
     </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Adds a "verify/preview" step to the importer.
This is in place of an "undo' button.

## Testing
* [ ] Begin an import from a file with more than 2 rows. The verify step should be the penultimate step, and it should accurately show how you've set everything up. After it the import should proceed as normal.
* [ ] Try again but with the sample CSV "samples\ee3-attendee-importer-sample-1-rows.csv". It should work but there will only be one row to preview.
* [ ] Try again but with the sample CSV "samples\ee3-attendee-importer-sample-0-rows.csv". The verify step shouldn't have an errors, there's just no data to preview.

## Checklist
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
