### PR TITLE
Bug/dont import blank rows

### DIFF
--- a/samples/ee3-attendee-importer-sample-with-blanks.csv
+++ b/samples/ee3-attendee-importer-sample-with-blanks.csv
@@ -1,0 +1,5 @@
+First,Last,Email,QTY,Event ID,Amount Paid,Payment Status,Price Option,Answers (optional)
+John,Doe,noreply@eventespresso.com,2,57,2.5,Completed,General Admission,4|| 6 | 7 |
+,,,,,,,,
+Jane,Doe,noreply@eventespresso.com,1,57,2.5,Completed,General Admission,"1,3,4"
+,,,,,,,,

--- a/src/domain/services/commands/ImportAnswersCommandHandler.php
+++ b/src/domain/services/commands/ImportAnswersCommandHandler.php
@@ -52,7 +52,7 @@ class ImportAnswersCommandHandler extends CommandHandler
         $answers = [];
         foreach ($this->config->getQuestionMapping() as $question_id => $csv_column) {
             $question = EEM_Question::instance()->get_one_by_ID($question_id);
-            $answer = $command->csvColumnValue($csv_column);
+            $answer = $command->valueFromInput($csv_column);
             if (EEM_Question::instance()->question_type_is_in_category($question->type(), 'multi-answer-enum')) {
                 $answer = array_map(
                     'trim',

--- a/src/domain/services/commands/ImportBaseCommand.php
+++ b/src/domain/services/commands/ImportBaseCommand.php
@@ -51,7 +51,7 @@ class ImportBaseCommand extends Command implements CommandRequiresCapCheckInterf
      * @since $VID:$
      * @return array
      */
-    public function csvRow()
+    public function inputData()
     {
         return $this->input_data;
     }
@@ -62,7 +62,7 @@ class ImportBaseCommand extends Command implements CommandRequiresCapCheckInterf
      * @param $column_name
      * @return string|null
      */
-    public function csvColumnValue($column_name)
+    public function valueFromInput($column_name)
     {
         return isset($this->input_data[ $column_name ]) ? $this->input_data[ $column_name ] : null;
     }

--- a/src/domain/services/commands/ImportCommand.php
+++ b/src/domain/services/commands/ImportCommand.php
@@ -48,4 +48,22 @@ class ImportCommand extends ImportBaseCommand
         }
         return $this->config;
     }
+
+    /**
+     * Checks if absolutely all datapoints are blank. If so, returns true. Otherwise, returns false.
+     * @since $VID:$
+     * @return bool
+     */
+    public function rowIsOnlyBlanks()
+    {
+        foreach ($this->inputData() as $column => $value) {
+            if (is_string($value)) {
+                $value = trim($value);
+            }
+            if ($value !== null && $value !== '') {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/domain/services/commands/ImportCommandHandler.php
+++ b/src/domain/services/commands/ImportCommandHandler.php
@@ -97,7 +97,7 @@ class ImportCommandHandler extends CompositeCommandHandler
                 ]
             )
         );
-        if ($payment instanceof EE_Payment){
+        if ($payment instanceof EE_Payment) {
             $this->commandBus()->execute(
                 $this->commandFactory()->getNew(
                     'EventEspresso\AttendeeImporter\domain\services\commands\ImportRegistrationPaymentCommand',

--- a/src/domain/services/commands/ImportSingleModelBase.php
+++ b/src/domain/services/commands/ImportSingleModelBase.php
@@ -54,12 +54,17 @@ class ImportSingleModelBase extends ImportBaseCommand
         $fields_mapped = $this->config->mapping();
         $fields = [];
         foreach ($fields_mapped as $field_mapped) {
-            /* @var $field_mapped ImportFieldMap */
-            $fields[ $field_mapped->destinationFieldName() ] = $field_mapped->applyMap(
-                $this->csvColumnValue(
-                    $field_mapped->sourceProperty()
-                )
+            $input_value = $this->valueFromInput(
+                $field_mapped->sourceProperty()
             );
+            if (is_null($input_value)) {
+                continue;
+            }
+            $input_datum = $field_mapped->applyMap(
+                $input_value
+            );
+            /* @var $field_mapped ImportFieldMap */
+            $fields[ $field_mapped->destinationFieldName() ] = $input_datum;
         }
         return $fields;
     }

--- a/src/domain/services/import/csv/attendees/config/ImportCsvAttendeesConfig.php
+++ b/src/domain/services/import/csv/attendees/config/ImportCsvAttendeesConfig.php
@@ -155,7 +155,7 @@ class ImportCsvAttendeesConfig extends ImportConfigBase
     {
         $this->question_mapping = [];
         foreach ($question_mapping as $question_id => $column) {
-            $this->question_mapping[ intval($question_id) ] = $column;
+            $this->question_mapping[ (int) $question_id ] = $column;
         }
     }
 

--- a/src/domain/services/import/csv/attendees/config/ImportCsvAttendeesConfig.php
+++ b/src/domain/services/import/csv/attendees/config/ImportCsvAttendeesConfig.php
@@ -154,8 +154,8 @@ class ImportCsvAttendeesConfig extends ImportConfigBase
     public function setQuestionMapping(array $question_mapping)
     {
         $this->question_mapping = [];
-        foreach($question_mapping as $question_id => $column) {
-            $this->question_mapping[intval( $question_id)] = $column;
+        foreach ($question_mapping as $question_id => $column) {
+            $this->question_mapping[ intval($question_id) ] = $column;
         }
     }
 

--- a/src/domain/services/import/csv/attendees/templates/attendee_importer_verify_info.template.php
+++ b/src/domain/services/import/csv/attendees/templates/attendee_importer_verify_info.template.php
@@ -1,6 +1,6 @@
 
-<p><b><?php esc_html_e('Event', 'event_espresso');?></b> <?php echo esc_html( $event instanceof EE_Event ? $event->name() : esc_html__('None', 'event_espresso'));?></p>
-<p><b><?php esc_html_e('Ticket', 'event_espresso');?></b> <?php echo esc_html( $ticket instanceof EE_Ticket ? $ticket->name() : esc_html__('None', 'event_espresso'));?></p>
+<p><b><?php esc_html_e('Event', 'event_espresso');?></b> <?php echo esc_html($event instanceof EE_Event ? $event->name() : esc_html__('None', 'event_espresso'));?></p>
+<p><b><?php esc_html_e('Ticket', 'event_espresso');?></b> <?php echo esc_html($ticket instanceof EE_Ticket ? $ticket->name() : esc_html__('None', 'event_espresso'));?></p>
 
 <table class="ee-responsive-table">
     <thead>

--- a/src/ui/admin/attendee_importer/Attendee_Importer_Admin_Page.core.php
+++ b/src/ui/admin/attendee_importer/Attendee_Importer_Admin_Page.core.php
@@ -140,16 +140,17 @@ class Attendee_Importer_Admin_Page extends EE_Admin_Page
     protected function main()
     {
         $import_manager = $this->getImportManager();
-        $import_type_ui_managaers = $import_manager->loadImportTypeUiManagers();
+        $import_type_ui_managers = $import_manager->loadImportTypeUiManagers();
 
         // If there's only one importer, don't bother asking what they want to import.
-        if (count($import_type_ui_managaers) === 1) {
-            $import_type = $import_type_ui_managaers->current();
+        if (count($import_type_ui_managers) === 1) {
+            $import_type = $import_type_ui_managers->current();
             $this->show_import_step($import_type->getSlug());
+            return;
         }
         
         $html = '';
-        foreach ($import_type_ui_managaers as $ui_manager) {
+        foreach ($import_type_ui_managers as $ui_manager) {
             $import_type = $ui_manager->getImportType();
             $html .= EEH_Template::display_template(
                 EE_ATTENDEE_IMPORTER_ADMIN_TEMPLATE_PATH . 'attendee_importer_manager_type.template.php',


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixes it so if there's a row that's totally blank in the CSV (even in the middle of it) we don't import all those blanks.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Import the sample CSV ee3-atendee-importer-sample-with-blanks.csv. There should be no attendees imported with blank names

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
