### PR TITLE
Update strings to use new helper method for branding

### DIFF
--- a/eea-attendee-importer.php
+++ b/eea-attendee-importer.php
@@ -38,7 +38,7 @@
  * ------------------------------------------------------------------------
  */
 // define versions and this file
-define('EE_ATTENDEE_IMPORTER_CORE_VERSION_REQUIRED', '4.9.80.p');
+define('EE_ATTENDEE_IMPORTER_CORE_VERSION_REQUIRED', '4.9.81.rc.009');
 define('EE_ATTENDEE_IMPORTER_VERSION', '1.0.0.dev.000');
 define('EE_ATTENDEE_IMPORTER_PLUGIN_FILE', __FILE__);
 

--- a/src/domain/services/import/csv/attendees/forms/forms/MapCsvColumnsSubform.php
+++ b/src/domain/services/import/csv/attendees/forms/forms/MapCsvColumnsSubform.php
@@ -11,6 +11,7 @@ use EEM_Event;
 use EEM_Question_Group;
 use EventEspresso\AttendeeImporter\domain\services\import\csv\attendees\config\ImportCsvAttendeesConfig;
 use EventEspresso\AttendeeImporter\application\services\import\mapping\ImportFieldMap;
+use EventEspresso\core\domain\Domain;
 
 /**
  * Class MapCsvColumnsSubform
@@ -210,13 +211,14 @@ class MapCsvColumnsSubform extends EE_Form_Section_Proper
                     $input2->add_validation_error(
                         sprintf(
                             esc_html__(
-                                // translators: %1$s CSV column name, %2$s Event Espresso Data name, %3$s CSV column name
+                                // translators: %1$s CSV column name, %2$s Event Espresso, %3$s Event Espresso Data name, %4$s CSV column name
                             // @codingStandardsIgnoreStart
-                                'CSV file column "%1$s" maps to the same Event Espresso data (%2$s) as "%3$s". This is not allowed.',
+                                'CSV file column "%1$s" maps to the same %2$s data (%3$s) as "%4$s". This is not allowed.',
                                 // @codingStandardsIgnoreEnd
                                 'event_espresso'
                             ),
                             $input1->html_label_text(),
+                            Domain::brandName(),
                             $input1->pretty_value(),
                             $input1->html_label_text()
                         )

--- a/src/domain/services/import/csv/attendees/templates/ee_attendee_importer_mapping_instructions.template.php
+++ b/src/domain/services/import/csv/attendees/templates/ee_attendee_importer_mapping_instructions.template.php
@@ -1,6 +1,15 @@
+<?php
+use EventEspresso\core\domain\Domain;
+?>
 <div class="ee-attendee-importer-mapping-instructions">
-    <p><?php esc_html_e('For each CSV column on the left, choose what Event Espresso data it will get mapped to during the import.', 'event_espresso');?></p>
-    <p><?php esc_html_e('The following Event Espresso data must be mapped to a column:', 'event_espresso');?></p>
+    <p><?php printf(
+    	esc_html__('For each CSV column on the left, choose what %s data it will get mapped to during the import.', 'event_espresso'),
+    	Domain::brandName()
+    );?></p>
+    <p><?php printf(
+    	esc_html__('The following %s data must be mapped to a column:', 'event_espresso'),
+    	Domain::brandName()
+    );?></p>
     <ul>
         <li><?php esc_html_e('First Name', 'event_espresso');?></li>
         <li><?php esc_html_e('Email Address', 'event_espresso');?></li>

--- a/src/ui/admin/attendee_importer/help_tabs/attendee_importer_import_map.help_tab.php
+++ b/src/ui/admin/attendee_importer/help_tabs/attendee_importer_import_map.help_tab.php
@@ -1,8 +1,22 @@
+<?php
+use EventEspresso\core\domain\Domain;
+?>
 <p>
-    <strong><?php esc_html_e('Map the CSV File’s Columns to Event Espresso Data', 'event_espresso');?></strong>
+    <strong>
+    	<?php printf(
+    		esc_html__('Map the CSV File’s Columns to %s Data', 'event_espresso'),
+    		Domain::brandName()
+    	);?>
+    </strong>
 </p>
 <p>
-    <?php esc_html_e('On the left are the names of columns found in the CSV file you just uploaded. In each dropdown list are the system questions, custom questions, and other Event Espresso data that can be populated from the cell’s value.', 'event_espresso'); ?>
+    <?php printf(
+    	esc_html__(
+    		'On the left are the names of columns found in the CSV file you just uploaded. In each dropdown list are the system questions, custom questions, and other %s data that can be populated from the cell’s value.',
+    		'event_espresso'
+    	),
+    	Domain::brandName()
+    ); ?>
 </p>
 <p>
     <?php esc_html_e('Only the First Name and Email system questions must be mapped, all others are optional. You can also leave columns unmapped if you like.', 'event_espresso'); ?>

--- a/src/ui/admin/attendee_importer/help_tabs/attendee_importer_import_overview.help_tab.php
+++ b/src/ui/admin/attendee_importer/help_tabs/attendee_importer_import_overview.help_tab.php
@@ -1,10 +1,21 @@
-<p><?php esc_html_e('Before Using the Event Espresso 4 Attendee Importer', 'event_espresso'); ?></p>
+<?php
+use EventEspresso\core\domain\Domain;
+?>
+<p>
+	<strong><?php printf(
+	esc_html__('Before Using the %s Attendee Importer', 'event_espresso'),
+	Domain::brandName()
+); ?></strong>
+</p>
 <p>
     <strong><?php esc_html_e('Backup', 'event_espresso');?></strong>
     <?php esc_html_e("Always make sure you have a complete database backup before performing an import.", 'event_espresso'); ?>
 </p>
 <p>
-    <strong><?php esc_html_e('Setup The Event in Event Espresso', 'event_espresso');?></strong>
+    <strong><?php printf(
+    	esc_html__('Setup The Event in %s', 'event_espresso'),
+    	Domain::brandName()
+    );?></strong>
 </p>
 <p>
     <?php esc_html_e("You must first create the event and ticket you wish to import the attendees to. Currently, only importing to one event ticket at a time is supported.", 'event_espresso'); ?>
@@ -22,5 +33,5 @@
     <?php esc_html_e('Complete the import configuration steps. You will have a chance to verify your configuration of the import before the data is actually imported. Before the verification step, use your browser’s back button if you like.', 'event_espresso'); ?>
 </p>
 <p>
-    <?php esc_html_e('If you import data improperly, or there is an error, the best way to undo the import is to restore to a backup, so please verify you have one..', 'event_espresso'); ?>
+    <?php esc_html_e('If you import data improperly, or there is an error, the best way to undo the import is to restore to a backup. So please verify you have a database backup before running the import.', 'event_espresso'); ?>
 </p>


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expedite acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
We shouldn't be doing this in localized strings:

```
esc_html__('Event Espresso is awesome', 'event_espresso');
```

Instead, we should be doing this:

```
sprintf( esc_html__('%1$s is awesome', 'event_espresso'), 'Event Espresso'));
```

Or even better:

```
sprintf( esc_html__('%1$s is awesome', 'event_espresso'), EventEspresso\core\domain\Constants::brandName())
```
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
